### PR TITLE
Fix mas check

### DIFF
--- a/System/mas.1d.sh
+++ b/System/mas.1d.sh
@@ -9,11 +9,9 @@
 # <bitbar.dependencies>mas</bitbar.dependencies>
 # <bitbar.abouturl>https://github.com/matryer/bitbar-plugins/blob/master/System/mas.1d.sh</bitbar.abouturl>
 
-if test $UPDATE_COUNT -gt 0; then
+if test `which /usr/local/bin/mas` 2> /dev/null; then
   UPDATES=$(/usr/local/bin/mas outdated);
-
   UPDATE_COUNT=$(echo "$UPDATES" | grep -c '[^[:space:]]');
-
   if test $UPDATE_COUNT -gt 0; then
     echo "↓$UPDATE_COUNT | dropdown=false"
     echo "---";
@@ -23,5 +21,5 @@ if test $UPDATE_COUNT -gt 0; then
     fi
   fi
 else
-  echo "`mas` not installed"
+  echo "mas not installed"
 fi


### PR DESCRIPTION
This is more of what I meant. I tested this on my one setup and and seems to do what I expected it to do:

- Check if mas is installed
- If it is, check it there are updates
- And only display in the menu bar if the update count is greater than 0